### PR TITLE
minibadge-cli: documenting building/running dependency in README.

### DIFF
--- a/minibage-cli/README.md
+++ b/minibage-cli/README.md
@@ -7,6 +7,9 @@ This is the command line tool for the End Summer Camp Mini Badge.
 If you don't have a Rust toolchain installed, follow the instructions in the firmware readme
 (directory `/antani_sw`).
 
+Additionally, the build process requires the `capnp` binary to be installed in
+your system. Please be sure it is installed before running the CLI tool.
+
 To run the CLI tool, just run `cargo run -- --help` in this directory.
 
 ```


### PR DESCRIPTION
Building minibadge-cli breaks when `capnp` binary is not present in the system.
Added a note to README.md to alert for it.